### PR TITLE
Fix bent Gooseberry Jam Cookie recipe.

### DIFF
--- a/src/main/resources/data/bayou_blues/recipes/crafting/gooseberry_jam_cookie_bent.json
+++ b/src/main/resources/data/bayou_blues/recipes/crafting/gooseberry_jam_cookie_bent.json
@@ -3,7 +3,7 @@
   "group": "cookie",
   "pattern": [
     "#X",
-    "X"
+    "X "
   ],
   "key": {
     "#": {


### PR DESCRIPTION
Each row in a shaped crafting pattern must be the same width. The space added in this commit fixes that.

(log with the error occuring looks something like `[11Aug2021 10:02:38.040] [Render thread/INFO] [net.minecraft.client.gui.NewChatGui/]: [CHAT] [3] Failed to parse recipe 'bayou_blues:crafting/gooseberry_jam_cookie_bent[minecraft:crafting_shaped]'! Falling back to vanilla: com.google.gson.JsonSyntaxException: Invalid pattern: each row must be the same width`)